### PR TITLE
Refactor main package 

### DIFF
--- a/cmd/cube/main.go
+++ b/cmd/cube/main.go
@@ -1,23 +1,10 @@
 package main
 
 import (
-	"context"
-	"crypto/tls"
-	"log"
-	"net/http"
 	"os"
 	"path/filepath"
-	"time"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/nsync/bulk"
-	"github.com/julz/cube/blobondemand"
-	"github.com/julz/cube/k8s"
-	"github.com/julz/cube/registry"
-	"github.com/julz/cube/sink"
 	"github.com/urfave/cli"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -26,120 +13,46 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "cube"
 	app.Usage = "Cube - the CF experience, on any scheduler"
-
-	app.Commands = append(app.Commands, cli.Command{
-		Name:  "registry",
-		Usage: "run an OCI registry backed by the CF blob store",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "rootfs",
-				Usage: "a tar file containing the rootfs",
-			},
-		},
-		Action: func(c *cli.Context) {
-			blobstore := blobondemand.NewInMemoryStore()
-
-			rootfsTar, err := os.Open(c.String("rootfs"))
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			rootfsDigest, rootfsSize, err := blobstore.Put(rootfsTar)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			log.Fatal(http.ListenAndServe("0.0.0.0:8080", registry.NewHandler(
-				registry.BlobRef{
-					Digest: rootfsDigest,
-					Size:   rootfsSize,
+	app.Commands = []cli.Command{
+		{
+			Name:  "registry",
+			Usage: "run an OCI registry backed by the CF blob store",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "rootfs",
+					Usage: "a tar file containing the rootfs",
 				},
-				make(registry.InMemoryDropletStore),
-				blobstore,
-			)))
+			},
+			Action: registryCmd,
 		},
-	})
-
-	app.Commands = append(app.Commands, cli.Command{
-		Name:  "sync",
-		Usage: "sync CC apps to a given backend",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "kubeconfig",
-				Usage: "path to kubernetes client config",
-				Value: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
+		{
+			Name:  "sync",
+			Usage: "sync CC apps to a given backend",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "kubeconfig",
+					Usage: "path to kubernetes client config",
+					Value: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
+				},
+				cli.StringFlag{
+					Name:  "ccApi",
+					Usage: "URL of the cloud controller api server",
+				},
+				cli.StringFlag{
+					Name:  "ccUser",
+					Value: "internal_user",
+				},
+				cli.StringFlag{
+					Name: "ccPass",
+				},
+				cli.StringFlag{
+					Name:  "backend",
+					Usage: "backend to use, currently only supported backend is k8s",
+				},
 			},
-			cli.StringFlag{
-				Name:  "ccApi",
-				Usage: "URL of the cloud controller api server",
-			},
-			cli.StringFlag{
-				Name:  "ccUser",
-				Value: "internal_user",
-			},
-			cli.StringFlag{
-				Name: "ccPass",
-			},
-			cli.StringFlag{
-				Name:  "backend",
-				Usage: "backend to use, currently only supported backend is k8s",
-			},
+			Action: syncCmd,
 		},
-		Action: func(c *cli.Context) {
-			fetcher := &bulk.CCFetcher{
-				BaseURI:   c.String("ccApi"),
-				BatchSize: 50,
-				Username:  c.String("ccUser"),
-				Password:  c.String("ccPass"),
-			}
-
-			config, err := clientcmd.BuildConfigFromFlags("", c.String("kubeconfig"))
-			if err != nil {
-				panic(err.Error())
-			}
-
-			clientset, err := kubernetes.NewForConfig(config)
-			if err != nil {
-				panic(err.Error())
-			}
-
-			converger := sink.Converger{
-				Converter: sink.ConvertFunc(sink.Convert),
-				Desirer:   &k8s.Desirer{Client: clientset},
-			}
-
-			log := lager.NewLogger("sync")
-			log.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
-
-			cancel := make(chan struct{})
-			client := &http.Client{Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}}
-
-			ticker := time.NewTicker(time.Second * 15)
-			for range ticker.C {
-				log.Info("tick", nil)
-
-				fingerprints, fpErr := fetcher.FetchFingerprints(log, cancel, client)
-				desired, desiredErr := fetcher.FetchDesiredApps(log, cancel, client, fingerprints)
-
-				if err := <-fpErr; err != nil {
-					log.Error("fetch-fingerprints-failed", err, lager.Data{"Err": err})
-					continue
-				}
-
-				select {
-				case err := <-desiredErr:
-					log.Error("fetch-desired-failed", err)
-					continue
-				case d := <-desired:
-					if err := converger.ConvergeOnce(context.Background(), d); err != nil {
-						log.Error("converge-once-failed", err)
-					}
-				}
-			}
-		},
-	})
+	}
 
 	app.Run(os.Args)
 }

--- a/cmd/cube/registry.go
+++ b/cmd/cube/registry.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/julz/cube/blobondemand"
+	"github.com/julz/cube/registry"
+	"github.com/urfave/cli"
+)
+
+func registryCmd(c *cli.Context) {
+	blobstore := blobondemand.NewInMemoryStore()
+
+	rootfsTar, err := os.Open(c.String("rootfs"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rootfsDigest, rootfsSize, err := blobstore.Put(rootfsTar)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Fatal(http.ListenAndServe("0.0.0.0:8080", registry.NewHandler(
+		registry.BlobRef{
+			Digest: rootfsDigest,
+			Size:   rootfsSize,
+		},
+		make(registry.InMemoryDropletStore),
+		blobstore,
+	)))
+}

--- a/cmd/cube/sync.go
+++ b/cmd/cube/sync.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/nsync/bulk"
+	"github.com/julz/cube/k8s"
+	"github.com/julz/cube/sink"
+	"github.com/urfave/cli"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func syncCmd(c *cli.Context) {
+	fetcher := &bulk.CCFetcher{
+		BaseURI:   c.String("ccApi"),
+		BatchSize: 50,
+		Username:  c.String("ccUser"),
+		Password:  c.String("ccPass"),
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", c.String("kubeconfig"))
+	if err != nil {
+		panic(err.Error())
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	converger := sink.Converger{
+		Converter: sink.ConvertFunc(sink.Convert),
+		Desirer:   &k8s.Desirer{Client: clientset},
+	}
+
+	log := lager.NewLogger("sync")
+	log.RegisterSink(lager.NewWriterSink(os.Stdout, lager.DEBUG))
+
+	cancel := make(chan struct{})
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	fetch(fetcher, converger, log, cancel, client)
+}
+
+func fetch(fetcher *bulk.CCFetcher, converger sink.Converger, log lager.Logger, cancel chan struct{}, client *http.Client) {
+	ticker := time.NewTicker(time.Second * 15)
+	for range ticker.C {
+		log.Info("tick", nil)
+
+		fingerprints, fpErr := fetcher.FetchFingerprints(log, cancel, client)
+		desired, desiredErr := fetcher.FetchDesiredApps(log, cancel, client, fingerprints)
+
+		if err := <-fpErr; err != nil {
+			log.Error("fetch-fingerprints-failed", err, lager.Data{"Err": err})
+			continue
+		}
+
+		select {
+		case err := <-desiredErr:
+			log.Error("fetch-desired-failed", err)
+			continue
+		case d := <-desired:
+			if err := converger.ConvergeOnce(context.Background(), d); err != nil {
+				log.Error("converge-once-failed", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a pure refactor (no implementation changes) and makes the code of the `main` package clearer, better to follow, and adds a separation of concerns. 

The changes include:

- move CLI command anonymous functions to private functions
- separate CLI flags (`main.go`) and command implementation into own files (now in `sync.go` and `registry.go`) .
- move/facade the "fetch" code from the `sync` command to it's own function 